### PR TITLE
add namespace coloring / icon / position

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,4 @@
+//% weight=99 color="#6d5ba5" icon="\uf004"
 namespace spritelives {
     const SPRITE_LIVES_EXTENSION_LIFE_DATA = "SPRITE_LIVES_EXTENSION_LIFE_DATA"
     let lifeZeroHandlers: { [key: number]: (sprite: Sprite) => void } = {}


### PR DESCRIPTION
Figured I'd add these real quick for you since you went through with making it an extension

this adds a color to the category, positions it next to sprites in the toolbox, and gives the category an icon (I made it a heart):

![image](https://user-images.githubusercontent.com/5615930/76914507-c8f33380-6877-11ea-8cf0-cff7aa05a7d7.png)

I just chose that real quick though, you can choose anything from here: https://fontawesome.com/v4.7.0/icons/ for the icon and any color you want :) also, if you pick a different icon, note that it gives you the icon as a 4 hex digit unicode representation (e.g. f004); you need to keep the `\u` in front of that for it to show up properly